### PR TITLE
fix: add contents:write permission for release uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+# Required for uploading release assets
+permissions:
+  contents: write
+
 # Prevent concurrent releases
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
Fixes 403 Forbidden error when uploading release assets. The workflow needs explicit write permission to upload to GitHub releases.